### PR TITLE
feat: add `--watch` to build command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,6 +1125,7 @@ name = "cargo-axiom"
 version = "0.1.0"
 dependencies = [
  "cargo-openvm",
+ "chrono",
  "clap",
  "comfy-table",
  "dialoguer",
@@ -1224,8 +1225,10 @@ checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ hex = "0.4.3"
 cargo-openvm = { git = "https://github.com/openvm-org/openvm.git", rev = "51f07d50d20174b23091f48e25d9ea421b4e2787" }
 openvm-sdk = { git = "https://github.com/openvm-org/openvm.git", rev = "51f07d50d20174b23091f48e25d9ea421b4e2787" }
 comfy-table = "6.1.4"
+chrono = "0.4"


### PR DESCRIPTION
Watches by polling the api until a final status.
Prints out logs if ends in error.

Written with Zed Agent

Example stdout:
```
Build request sent successfully: 9d7f4005-bcc5-472c-bf64-ccd87e927fde
Watching build status...
[2025-04-17 19:08:47] Build status: not_ready
[2025-04-17 19:08:52] Build status: processing
[2025-04-17 19:08:57] Build status: processing
[2025-04-17 19:09:03] Build status: processing
[2025-04-17 19:09:08] Build status: processing
[2025-04-17 19:09:13] Build status: processing
[2025-04-17 19:09:19] Build status: processing
[2025-04-17 19:09:24] Build status: processing
[2025-04-17 19:09:29] Build status: processing
[2025-04-17 19:09:35] Build status: processing
[2025-04-17 19:09:40] Build status: processing
[2025-04-17 19:09:46] Build status: processing
[2025-04-17 19:09:51] Build status: processing
[2025-04-17 19:09:56] Build status: processing
[2025-04-17 19:10:02] Build status: processing
[2025-04-17 19:10:07] Build status: processing
[2025-04-17 19:10:13] Build status: processing
[2025-04-17 19:10:18] Build status: processing
[2025-04-17 19:10:23] Build status: processing
[2025-04-17 19:10:29] Build status: processing
[2025-04-17 19:10:34] Build status: processing
[2025-04-17 19:10:40] Build status: processing
[2025-04-17 19:10:45] Build status: processing
[2025-04-17 19:10:50] Build status: processing
[2025-04-17 19:10:56] Build status: ready
Build completed successfully!
```