### PR TITLE
fix: small cli fixes

### DIFF
--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -5,14 +5,14 @@
 1. Install the Axiom CLI:
 
    ```
-   cargo install --locked --git https://github.com/axiom-crypto/axiom-api-cli.git --tag v0.3.0 cargo-axiom
+   cargo install --locked --git https://github.com/axiom-crypto/axiom-api-cli.git --tag v0.4.0 cargo-axiom
    ```
 
    Or from source:
 
    ```bash
    git clone https://github.com/axiom-crypto/axiom-api-cli
-   cd axiom-api-cli
+   cd axiom-api-cli/crates/cli
    cargo install --locked --force --path .
    ```
 

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -1,6 +1,4 @@
-use axiom_sdk::{
-    load_config_without_validation, AxiomConfig, DEFAULT_CONFIG_ID, STAGING_DEFAULT_CONFIG_ID,
-};
+use axiom_sdk::{AxiomConfig, DEFAULT_CONFIG_ID, STAGING_DEFAULT_CONFIG_ID};
 use clap::Parser;
 use eyre::Result;
 
@@ -22,7 +20,7 @@ impl InitCmd {
 
 #[derive(Debug, Parser)]
 pub struct InitArgs {
-    /// The API URL to use (defaults to https://api.staging.app.axiom.xyz)
+    /// The API URL to use (defaults to https://api.axiom.xyz/v1)
     #[clap(long, value_name = "URL")]
     api_url: Option<String>,
 
@@ -62,8 +60,7 @@ pub fn execute(args: InitArgs) -> Result<()> {
         Some(DEFAULT_CONFIG_ID.to_string())
     };
 
-    let config = load_config_without_validation()
-        .unwrap_or_else(|_| AxiomConfig::new(api_url, api_key, config_id));
+    let config = AxiomConfig::new(api_url, api_key, config_id);
 
     axiom_sdk::save_config(&config)?;
 

--- a/crates/sdk/src/build.rs
+++ b/crates/sdk/src/build.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tar::Builder;
 
-use crate::{get_config_id, AxiomSdk, API_KEY_HEADER};
+use crate::{AxiomSdk, API_KEY_HEADER};
 
 pub const MAX_PROGRAM_SIZE_MB: u64 = 1024;
 
@@ -285,10 +285,16 @@ impl BuildSdk for AxiomSdk {
             ));
         }
 
-        // Get the config_id from args, return error if not provided
+        // Use config id if it was provided
         let config_id = if let Some(ConfigSource::ConfigId(id)) = args.config_source.clone() {
-            Some(get_config_id(Some(id.as_str()), &self.config)?)
-        } else {
+            Some(id.to_string())
+        }
+        // Otherwise check if there is a config id in the config file
+        else if let Some(id) = &self.config.config_id {
+            Some(id.to_string())
+        }
+        // Otherwise return an error
+         else {
             None
         };
 


### PR DESCRIPTION
This PR fixes the following:
- Actually populates the passed in `--api-key` in the `init` command into the outputted `config.json`
- If no `--config-id` is provided in the `build` command, it should try to read the config id from the config.json