### PR TITLE
chore: print statuses as json instead of rust structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,6 +948,7 @@ dependencies = [
  "comfy-table",
  "dotenv",
  "eyre",
+ "serde_json",
  "tokio",
 ]
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,6 +15,7 @@ tokio = { version = "1", features = ["full"] }
 eyre = "0.6.12"
 comfy-table = { version = "6.1.4", default-features = false }
 dotenv = "0.15.0"
+serde_json = "1.0.140"
 
 [build-dependencies]
 cargo_metadata = "0.18"

--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -84,7 +84,10 @@ impl BuildCmd {
         match self.command {
             Some(BuildSubcommand::Status { program_id }) => {
                 let build_status = sdk.get_build_status(&program_id)?;
-                println!("Build status: {}", serde_json::to_string(&build_status).unwrap());
+                println!(
+                    "Build status: {}",
+                    serde_json::to_string(&build_status).unwrap()
+                );
                 Ok(())
             }
             Some(BuildSubcommand::List) => {

--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -84,7 +84,7 @@ impl BuildCmd {
         match self.command {
             Some(BuildSubcommand::Status { program_id }) => {
                 let build_status = sdk.get_build_status(&program_id)?;
-                println!("Build status: {:?}", build_status);
+                println!("Build status: {}", serde_json::to_string(&build_status).unwrap());
                 Ok(())
             }
             Some(BuildSubcommand::List) => {

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -70,7 +70,10 @@ impl ProveCmd {
         match self.command {
             Some(ProveSubcommand::Status { proof_id }) => {
                 let proof_status = sdk.get_proof_status(&proof_id)?;
-                println!("Proof status: {}", serde_json::to_string(&proof_status).unwrap());
+                println!(
+                    "Proof status: {}",
+                    serde_json::to_string(&proof_status).unwrap()
+                );
                 Ok(())
             }
             Some(ProveSubcommand::Download {

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -70,7 +70,7 @@ impl ProveCmd {
         match self.command {
             Some(ProveSubcommand::Status { proof_id }) => {
                 let proof_status = sdk.get_proof_status(&proof_id)?;
-                println!("Proof status: {:?}", proof_status);
+                println!("Proof status: {}", serde_json::to_string(&proof_status).unwrap());
                 Ok(())
             }
             Some(ProveSubcommand::Download {

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -36,7 +36,10 @@ impl VerifyCmd {
         match self.command {
             Some(VerifySubcommand::Status { verify_id }) => {
                 let verify_status = sdk.get_verification_result(&verify_id)?;
-                println!("Verification status: {}", serde_json::to_string(&verify_status).unwrap());
+                println!(
+                    "Verification status: {}",
+                    serde_json::to_string(&verify_status).unwrap()
+                );
                 Ok(())
             }
             None => {

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -36,7 +36,7 @@ impl VerifyCmd {
         match self.command {
             Some(VerifySubcommand::Status { verify_id }) => {
                 let verify_status = sdk.get_verification_result(&verify_id)?;
-                println!("Verification status: {:?}", verify_status);
+                println!("Verification status: {}", serde_json::to_string(&verify_status).unwrap());
                 Ok(())
             }
             None => {


### PR DESCRIPTION
This PR prints the status structs as JSON instead of the rust debug print which makes it easier to parse (as is done in the cloud backend integration tests).