### PR TITLE
refactor: separate config downloading for more consistent terminology

### DIFF
--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -86,7 +86,7 @@ impl BuildCmd {
                 let build_status = sdk.get_build_status(&program_id)?;
                 println!(
                     "Build status: {}",
-                    serde_json::to_string(&build_status).unwrap()
+                    serde_json::to_string_pretty(&build_status).unwrap()
                 );
                 Ok(())
             }

--- a/crates/cli/src/commands/download_keys.rs
+++ b/crates/cli/src/commands/download_keys.rs
@@ -1,0 +1,38 @@
+use std::path::PathBuf;
+
+use axiom_sdk::{config::ConfigSdk, AxiomSdk};
+use clap::Args;
+use eyre::Result;
+
+#[derive(Args, Debug)]
+pub struct DownloadKeysCmd {
+    /// The config ID to download public key for
+    #[clap(long, value_name = "ID")]
+    config_id: Option<String>,
+
+    /// The type of key to download
+    #[clap(long, value_parser = [
+        "app_vm",
+        "leaf_vm",
+        "internal_vm",
+        "root_verifier",
+        "halo2_outer",
+        "halo2_wrapper",
+    ])]
+    r#type: String,
+
+    /// Optional output file path (defaults to key_type name in current directory)
+    #[clap(long, value_name = "FILE")]
+    output: Option<PathBuf>,
+}
+
+impl DownloadKeysCmd {
+    pub fn run(self) -> Result<()> {
+        let config = axiom_sdk::load_config()?;
+        let sdk = AxiomSdk::new(config);
+
+        let pk_downloader = sdk.get_proving_keys(self.config_id.as_deref(), &self.r#type)?;
+        println!("Download URL: {}", pk_downloader.download_url);
+        Ok(())
+    }
+}

--- a/crates/cli/src/commands/download_keys.rs
+++ b/crates/cli/src/commands/download_keys.rs
@@ -11,7 +11,7 @@ pub struct DownloadKeysCmd {
     config_id: Option<String>,
 
     /// The type of key to download
-    #[clap(long, value_parser = [
+    #[clap(long = "type", value_parser = [
         "app_vm",
         "leaf_vm",
         "internal_vm",
@@ -19,7 +19,7 @@ pub struct DownloadKeysCmd {
         "halo2_outer",
         "halo2_wrapper",
     ])]
-    r#type: String,
+    key_type: String,
 
     /// Optional output file path (defaults to key_type name in current directory)
     #[clap(long, value_name = "FILE")]
@@ -31,7 +31,7 @@ impl DownloadKeysCmd {
         let config = axiom_sdk::load_config()?;
         let sdk = AxiomSdk::new(config);
 
-        let pk_downloader = sdk.get_proving_keys(self.config_id.as_deref(), &self.r#type)?;
+        let pk_downloader = sdk.get_proving_keys(self.config_id.as_deref(), &self.key_type)?;
         println!("Download URL: {}", pk_downloader.download_url);
         Ok(())
     }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod build;
 pub mod config;
+pub mod download_keys;
 pub mod init;
 pub mod prove;
 pub mod run;
@@ -8,6 +9,7 @@ pub mod version;
 
 pub use build::BuildCmd;
 pub use config::ConfigCmd;
+pub use download_keys::DownloadKeysCmd;
 pub use init::InitCmd;
 pub use prove::ProveCmd;
 pub use run::RunCmd;

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -76,7 +76,7 @@ impl ProveCmd {
                 let proof_status = sdk.get_proof_status(&proof_id)?;
                 println!(
                     "Proof status: {}",
-                    serde_json::to_string(&proof_status).unwrap()
+                    serde_json::to_string_pretty(&proof_status).unwrap()
                 );
                 Ok(())
             }

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -38,7 +38,7 @@ impl VerifyCmd {
                 let verify_status = sdk.get_verification_result(&verify_id)?;
                 println!(
                     "Verification status: {}",
-                    serde_json::to_string(&verify_status).unwrap()
+                    serde_json::to_string_pretty(&verify_status).unwrap()
                 );
                 Ok(())
             }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5,7 +5,9 @@ use dotenv::dotenv;
 
 mod commands;
 
-use commands::{BuildCmd, ConfigCmd, InitCmd, ProveCmd, RunCmd, VerifyCmd, VersionCmd};
+use commands::{
+    BuildCmd, ConfigCmd, DownloadKeysCmd, InitCmd, ProveCmd, RunCmd, VerifyCmd, VersionCmd,
+};
 
 #[derive(Parser)]
 #[command(name = "cargo", bin_name = "cargo")]
@@ -37,6 +39,9 @@ enum AxiomCommands {
     Run(RunCmd),
     /// Generate key artifacts
     Config(ConfigCmd),
+    /// Download proving keys
+    #[command(name = "download-keys")]
+    DownloadKeys(DownloadKeysCmd),
     /// Verify a proof using the Axiom Verifying Service
     Verify(VerifyCmd),
     /// Display version information
@@ -55,6 +60,7 @@ async fn main() {
         AxiomCommands::Prove(cmd) => cmd.run(),
         AxiomCommands::Run(cmd) => cmd.run(),
         AxiomCommands::Config(cmd) => cmd.run(),
+        AxiomCommands::DownloadKeys(cmd) => cmd.run(),
         AxiomCommands::Verify(cmd) => cmd.run(),
         AxiomCommands::Version(cmd) => cmd.run(),
     };

--- a/crates/sdk/src/config.rs
+++ b/crates/sdk/src/config.rs
@@ -27,6 +27,8 @@ pub struct VmConfigMetadata {
     pub stark_backend_version: String,
     pub status: String,
     pub active: bool,
+    #[serde(rename = "app_vm_config")]
+    pub app_vm_commit: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
Previously, we had 

```
cargo axiom config download --key-type [app_vm, leaf_vm, internal_vm, root_verifier, halo2_outer, halo2_wrapper, config, evm_verifier, app_vm_commit]
```

Now we have 

```
cargo axiom download-keys [app_vm, leaf_vm, internal_vm, root_verifier, halo2_outer, halo2_wrapper]

cargo axiom config get   # gets metadata
cargo axiom config download    # downloads openvm.toml
cargo axiom config download --evm-verifier   # downloads EVM verifier
```

Closes INT-3717