### PR TITLE
fix: quick fix for `verify_id` usage

### DIFF
--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -54,7 +54,8 @@ impl VerifyCmd {
                     sdk.wait_for_verify_completion(&verify_id)
                 } else {
                     println!(
-                        "To check the verification status, run: cargo axiom verify status --verify-id {verify_id}"
+                        "To check the verification status, run: cargo axiom verify status --verify-id {verify_id}",
+                        verify_id
                     );
                     Ok(())
                 }


### PR DESCRIPTION
spotted that `verify_id` wasn’t actually being passed in properly - it was just thrown in with curly braces, which doesn’t work.
tweaked it to pass `verify_id` as an argument, and now it’s behaving correctly.
