### PR TITLE
feat: verify stark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,7 +1036,6 @@ dependencies = [
  "dotenvy",
  "eyre",
  "serde_json",
- "tokio",
  "toml_edit 0.23.2",
 ]
 
@@ -3046,16 +3045,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "lockfree-object-pool"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4704,29 +4693,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "pasta_curves"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6119,7 +6085,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,7 +14,6 @@ comfy-table = { workspace = true }
 serde_json = { workspace = true }
 
 clap = { version = "4.4", features = ["derive"] }
-tokio = { version = "1", features = ["full"] }
 eyre = "0.6.12"
 dotenvy = "0.15.7"
 toml_edit = { workspace = true }

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -1,34 +1,57 @@
 use std::path::PathBuf;
 
-use axiom_sdk::{AxiomSdk, verify::VerifySdk};
+use axiom_sdk::{
+    AxiomSdk,
+    verify::{ProofType, VerifySdk},
+};
 use clap::{Args, Subcommand};
-use eyre::{OptionExt, Result};
+use eyre::Result;
 
 #[derive(Args, Debug)]
 pub struct VerifyCmd {
     #[command(subcommand)]
-    command: Option<VerifySubcommand>,
-
-    /// The config ID to use for verification
-    #[clap(long, value_name = "ID")]
-    config_id: Option<String>,
-
-    /// Path to the proof file
-    #[clap(long, value_name = "FILE")]
-    proof: Option<PathBuf>,
-
-    /// Wait for the verification to complete
-    #[clap(long)]
-    wait: bool,
+    command: VerifySubcommand,
 }
 
 #[derive(Debug, Subcommand)]
 enum VerifySubcommand {
+    /// Verify an EVM proof
+    Evm {
+        /// The config ID to use for verification
+        #[clap(long, value_name = "ID")]
+        config_id: Option<String>,
+
+        /// Path to the proof file
+        #[clap(long, value_name = "FILE")]
+        proof: PathBuf,
+
+        /// Wait for the verification to complete
+        #[clap(long)]
+        wait: bool,
+    },
+    /// Verify a STARK proof
+    Stark {
+        /// The program ID to use for verification
+        #[clap(long, value_name = "ID")]
+        program_id: String,
+
+        /// Path to the proof file
+        #[clap(long, value_name = "FILE")]
+        proof: PathBuf,
+
+        /// Wait for the verification to complete
+        #[clap(long)]
+        wait: bool,
+    },
     /// Check the status of a verification
     Status {
         /// The verification ID to check status for
         #[clap(long, value_name = "ID")]
         verify_id: String,
+
+        /// The proof type (evm or stark)
+        #[clap(long, value_name = "TYPE")]
+        proof_type: ProofType,
     },
 }
 
@@ -38,20 +61,15 @@ impl VerifyCmd {
         let sdk = AxiomSdk::new(config);
 
         match self.command {
-            Some(VerifySubcommand::Status { verify_id }) => {
-                let verify_status = sdk.get_verification_result(&verify_id)?;
-                Self::print_verify_status(&verify_status);
-                Ok(())
-            }
-            None => {
-                let proof = self
-                    .proof
-                    .ok_or_eyre("Proof file is required. Use --proof to specify.")?;
+            VerifySubcommand::Evm {
+                config_id,
+                proof,
+                wait,
+            } => {
+                let verify_id = sdk.verify_evm(config_id.as_deref(), proof)?;
 
-                let verify_id = sdk.verify_proof(self.config_id.as_deref(), proof)?;
-
-                if self.wait {
-                    sdk.wait_for_verify_completion(&verify_id)
+                if wait {
+                    sdk.wait_for_evm_verify_completion(&verify_id)
                 } else {
                     println!(
                         "To check the verification status, run: cargo axiom verify status --verify-id {verify_id}"
@@ -59,14 +77,42 @@ impl VerifyCmd {
                     Ok(())
                 }
             }
+            VerifySubcommand::Stark {
+                program_id,
+                proof,
+                wait,
+            } => {
+                let verify_id = sdk.verify_stark(&program_id, proof)?;
+
+                if wait {
+                    sdk.wait_for_stark_verify_completion(&verify_id)
+                } else {
+                    println!(
+                        "To check the verification status, run: cargo axiom verify status --verify-id {verify_id} --proof-type stark"
+                    );
+                    Ok(())
+                }
+            }
+            VerifySubcommand::Status {
+                verify_id,
+                proof_type,
+            } => {
+                let verify_status = match proof_type {
+                    ProofType::Evm => sdk.get_evm_verification_result(&verify_id)?,
+                    ProofType::Stark => sdk.get_stark_verification_result(&verify_id)?,
+                };
+                Self::print_verify_status(&verify_status, proof_type);
+                Ok(())
+            }
         }
     }
 
-    fn print_verify_status(status: &axiom_sdk::verify::VerifyStatus) {
+    fn print_verify_status(status: &axiom_sdk::verify::VerifyStatus, proof_type: ProofType) {
         use axiom_sdk::formatting::Formatter;
 
         Formatter::print_section("Verification Status");
         Formatter::print_field("ID", &status.id);
+        Formatter::print_field("Proof Type", &proof_type.to_string().to_uppercase());
         Formatter::print_field("Result", &status.result);
         Formatter::print_field("Created At", &status.created_at);
     }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -53,8 +53,7 @@ enum AxiomCommands {
     Version(VersionCmd),
 }
 
-#[tokio::main]
-async fn main() {
+fn main() {
     dotenv().ok();
 
     let Cargo::Axiom(args) = Cargo::parse();


### PR DESCRIPTION
The paired CLI changes to the API's support of verifying STARK proofs. 

I'm also not sure since when the CLI can't parse `0x`-prepended hex strings for EVM proofs but this PR addresses it. Both STARK and EVM proof verification were tested. Below are some examples:

```bash
cargo run -- axiom verify evm --proof <EVM-PROOF>

cargo run -- axiom verify stark --program-id c363fafe-9b2f-4aa1-bbf1-3ef95edf0833 --proof <STARK-PROOF>
```

Closes INT-4690