### PR TITLE
style: add missing subcommand descriptions

### DIFF
--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -25,6 +25,7 @@ enum BuildSubcommand {
         program_id: String,
     },
 
+    /// List all build programs
     List,
 
     /// Download build artifacts
@@ -38,6 +39,7 @@ enum BuildSubcommand {
         program_type: String,
     },
 
+    /// Download build logs for a program
     Logs {
         /// The program ID to download logs for
         #[clap(long, value_name = "ID")]

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -44,6 +44,7 @@ enum ProveSubcommand {
         output: Option<PathBuf>,
     },
 
+    /// List all proofs for a program
     List {
         /// The ID of the program to list proofs for
         #[arg(long)]


### PR DESCRIPTION
They are shown in `--help` section.

Previously:
```
❯ cargo axiom build --help

Build the project on Axiom Proving Service

Usage: cargo axiom build [OPTIONS] [COMMAND]

Commands:
  status    Check the status of a build
  list      
  download  Download build artifacts
  logs      
  help      Print this message or the help of the given subcommand(s)
  
  ...
  ```