### PR TITLE
docs: consistent <ID> parameters

### DIFF
--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -74,7 +74,7 @@ pub struct BuildArgs {
     include_dirs: Option<String>,
 
     /// The project ID to associate with the build
-    #[arg(long)]
+    #[arg(long, value_name = "ID")]
     project_id: Option<String>,
     /// Wait for the build to complete and download artifacts
     #[clap(long)]

--- a/crates/cli/src/commands/projects.rs
+++ b/crates/cli/src/commands/projects.rs
@@ -28,13 +28,13 @@ enum ProjectsSubcommand {
     /// Show details for a specific project
     Show {
         /// Project ID to show details for
-        #[arg(long)]
+        #[arg(long, value_name = "ID")]
         project_id: String,
     },
     /// List programs in a project
     Programs {
         /// Project ID to list programs for
-        #[arg(long)]
+        #[arg(long, value_name = "ID")]
         project_id: String,
         /// Page number (default: 1)
         #[arg(long, default_value = "1")]
@@ -46,10 +46,10 @@ enum ProjectsSubcommand {
     /// Move a program to a different project
     Move {
         /// Program ID to move
-        #[arg(long)]
+        #[arg(long, value_name = "ID")]
         program_id: String,
         /// Target project ID to move program to
-        #[arg(long)]
+        #[arg(long, value_name = "ID")]
         to_project: String,
     },
 }

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -47,7 +47,7 @@ enum ProveSubcommand {
     /// List all proofs for a program
     List {
         /// The ID of the program to list proofs for
-        #[arg(long)]
+        #[arg(long, value_name = "ID")]
         program_id: String,
     },
 }
@@ -55,7 +55,7 @@ enum ProveSubcommand {
 #[derive(Args, Debug)]
 pub struct ProveArgs {
     /// The ID of the program to generate a proof for
-    #[arg(long)]
+    #[arg(long, value_name = "ID")]
     program_id: Option<String>,
 
     /// Input data for the proof (file path or hex string)

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -25,7 +25,7 @@ enum RunSubcommand {
 #[derive(Args, Debug)]
 pub struct RunArgs {
     /// The ID of the program to execute
-    #[arg(long)]
+    #[arg(long, value_name = "ID")]
     program_id: Option<String>,
 
     /// Input data for the execution (file path or hex string)


### PR DESCRIPTION
Alternative could be to use long name like <PROJECT_ID> everywhere but I decided to use short ones because
1. We mostly used <ID> already
2. I think it should be always obvious from the contexts as we have arguments like --project-id