### PR TITLE
[feat] cache project id in the local dir

### DIFF
--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -134,8 +134,6 @@ impl BuildCmd {
                     (None, None) => None,
                 };
 
-                // let project_id =
-                //     axiom_sdk::get_project_id(self.build_args.project_id.as_deref(), &config);
                 let project_id = {
                     let cache_path = program_dir.join(".axiom").join("project-id");
                     match std::fs::read_to_string(&cache_path) {

--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -134,8 +134,22 @@ impl BuildCmd {
                     (None, None) => None,
                 };
 
-                let project_id =
-                    axiom_sdk::get_project_id(self.build_args.project_id.as_deref(), &config);
+                // let project_id =
+                //     axiom_sdk::get_project_id(self.build_args.project_id.as_deref(), &config);
+                let project_id = {
+                    let cache_path = program_dir.join(".axiom").join("project-id");
+                    match std::fs::read_to_string(&cache_path) {
+                        Ok(contents) => {
+                            let trimmed = contents.trim();
+                            if trimmed.is_empty() {
+                                None
+                            } else {
+                                Some(trimmed.to_string())
+                            }
+                        }
+                        Err(_) => None,
+                    }
+                };
                 if let Some(pid) = &project_id {
                     println!("Using project ID: {pid}");
                 }
@@ -149,6 +163,23 @@ impl BuildCmd {
                     project_id,
                 };
                 let program_id = sdk.register_new_program(&program_dir, args)?;
+
+                // If no cached project ID existed, fetch and cache it after registration
+                {
+                    let cache_dir = program_dir.join(".axiom");
+                    let cache_path = cache_dir.join("project-id");
+                    if !cache_path.exists() {
+                        if let Ok(status) = sdk.get_build_status(&program_id) {
+                            if let Err(e) = std::fs::create_dir_all(&cache_dir) {
+                                eprintln!("Warning: failed to create .axiom directory: {e}");
+                            } else if let Err(e) =
+                                std::fs::write(&cache_path, status.project_id.as_bytes())
+                            {
+                                eprintln!("Warning: failed to write project ID cache: {e}");
+                            }
+                        }
+                    }
+                }
 
                 if self.build_args.wait {
                     sdk.wait_for_build_completion(&program_id)

--- a/crates/cli/src/commands/projects.rs
+++ b/crates/cli/src/commands/projects.rs
@@ -105,9 +105,6 @@ impl ProjectsCmd {
             ProjectsSubcommand::Create { name } => {
                 let response = sdk.create_project(&name)?;
 
-                // Save this as the current project
-                // axiom_sdk::set_project_id(&response.id)?;
-
                 println!("✓ Created project '{}' with ID: {}", name, response.id);
                 println!("✓ Saved project ID {} for future use", response.id);
                 Ok(())

--- a/crates/cli/src/commands/projects.rs
+++ b/crates/cli/src/commands/projects.rs
@@ -106,7 +106,7 @@ impl ProjectsCmd {
                 let response = sdk.create_project(&name)?;
 
                 // Save this as the current project
-                axiom_sdk::set_project_id(&response.id)?;
+                // axiom_sdk::set_project_id(&response.id)?;
 
                 println!("✓ Created project '{}' with ID: {}", name, response.id);
                 println!("✓ Saved project ID {} for future use", response.id);

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -505,44 +505,6 @@ mod tests {
         assert_eq!(config.config_id, Some("test-config".to_string()));
     }
 
-    // #[test]
-    // fn test_get_project_id_with_args() {
-    //     let config = AxiomConfig::default();
-
-    //     // Mock save_config to avoid file system operations
-    //     let project_id = "123e4567-e89b-12d3-a456-426614174000";
-    //     let result = get_project_id(Some(project_id), &config);
-
-    //     // Should return the provided project_id
-    //     assert_eq!(result, Some(project_id.to_string()));
-    // }
-
-    // #[test]
-    // fn test_get_project_id_from_config() {
-    //     let config = AxiomConfig {
-    //         last_project_id: Some("456e4567-e89b-12d3-a456-426614174001".to_string()),
-    //         ..Default::default()
-    //     };
-
-    //     let result = get_project_id(None, &config);
-
-    //     // Should return the config's project_id
-    //     assert_eq!(
-    //         result,
-    //         Some("456e4567-e89b-12d3-a456-426614174001".to_string())
-    //     );
-    // }
-
-    // #[test]
-    // fn test_get_project_id_none() {
-    //     let config = AxiomConfig::default();
-
-    //     let result = get_project_id(None, &config);
-
-    //     // Should return None when no project_id available
-    //     assert_eq!(result, None);
-    // }
-
     #[test]
     fn test_axiom_config_serialization() {
         let config = AxiomConfig {

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -178,7 +178,6 @@ pub struct AxiomConfig {
     pub api_url: String,
     pub api_key: Option<String>,
     pub config_id: Option<String>,
-    pub last_project_id: Option<String>,
 }
 
 impl AxiomConfig {
@@ -187,7 +186,6 @@ impl AxiomConfig {
             api_url,
             api_key,
             config_id,
-            last_project_id: None,
         }
     }
 }
@@ -198,7 +196,6 @@ impl Default for AxiomConfig {
             api_url: "https://api.axiom.xyz/v1".to_string(),
             api_key: None,
             config_id: Some(DEFAULT_CONFIG_ID.to_string()),
-            last_project_id: None,
         }
     }
 }
@@ -299,22 +296,6 @@ pub fn get_config_id(args_config_id: Option<&str>, config: &AxiomConfig) -> Resu
         Ok(id.clone())
     } else {
         Err(eyre::eyre!("No config ID provided"))
-    }
-}
-
-pub fn set_project_id(id: &str) -> Result<()> {
-    let mut config = load_config()?;
-    config.last_project_id = Some(id.to_string());
-    save_config(&config)
-}
-
-pub fn get_project_id(args_project_id: Option<&str>, config: &AxiomConfig) -> Option<String> {
-    if let Some(id) = args_project_id {
-        // Try to save it, but return the ID regardless
-        let _ = set_project_id(id);
-        Some(id.to_string())
-    } else {
-        config.last_project_id.clone()
     }
 }
 
@@ -510,7 +491,6 @@ mod tests {
         assert_eq!(config.api_url, "https://api.axiom.xyz/v1");
         assert!(config.api_key.is_none());
         assert_eq!(config.config_id, Some(DEFAULT_CONFIG_ID.to_string()));
-        assert!(config.last_project_id.is_none());
     }
 
     #[test]
@@ -523,46 +503,45 @@ mod tests {
         assert_eq!(config.api_url, "https://test.api.com");
         assert_eq!(config.api_key, Some("test-key".to_string()));
         assert_eq!(config.config_id, Some("test-config".to_string()));
-        assert!(config.last_project_id.is_none());
     }
 
-    #[test]
-    fn test_get_project_id_with_args() {
-        let config = AxiomConfig::default();
+    // #[test]
+    // fn test_get_project_id_with_args() {
+    //     let config = AxiomConfig::default();
 
-        // Mock save_config to avoid file system operations
-        let project_id = "123e4567-e89b-12d3-a456-426614174000";
-        let result = get_project_id(Some(project_id), &config);
+    //     // Mock save_config to avoid file system operations
+    //     let project_id = "123e4567-e89b-12d3-a456-426614174000";
+    //     let result = get_project_id(Some(project_id), &config);
 
-        // Should return the provided project_id
-        assert_eq!(result, Some(project_id.to_string()));
-    }
+    //     // Should return the provided project_id
+    //     assert_eq!(result, Some(project_id.to_string()));
+    // }
 
-    #[test]
-    fn test_get_project_id_from_config() {
-        let config = AxiomConfig {
-            last_project_id: Some("456e4567-e89b-12d3-a456-426614174001".to_string()),
-            ..Default::default()
-        };
+    // #[test]
+    // fn test_get_project_id_from_config() {
+    //     let config = AxiomConfig {
+    //         last_project_id: Some("456e4567-e89b-12d3-a456-426614174001".to_string()),
+    //         ..Default::default()
+    //     };
 
-        let result = get_project_id(None, &config);
+    //     let result = get_project_id(None, &config);
 
-        // Should return the config's project_id
-        assert_eq!(
-            result,
-            Some("456e4567-e89b-12d3-a456-426614174001".to_string())
-        );
-    }
+    //     // Should return the config's project_id
+    //     assert_eq!(
+    //         result,
+    //         Some("456e4567-e89b-12d3-a456-426614174001".to_string())
+    //     );
+    // }
 
-    #[test]
-    fn test_get_project_id_none() {
-        let config = AxiomConfig::default();
+    // #[test]
+    // fn test_get_project_id_none() {
+    //     let config = AxiomConfig::default();
 
-        let result = get_project_id(None, &config);
+    //     let result = get_project_id(None, &config);
 
-        // Should return None when no project_id available
-        assert_eq!(result, None);
-    }
+    //     // Should return None when no project_id available
+    //     assert_eq!(result, None);
+    // }
 
     #[test]
     fn test_axiom_config_serialization() {
@@ -570,7 +549,6 @@ mod tests {
             api_url: "https://test.api.com/v1".to_string(),
             api_key: Some("test-key".to_string()),
             config_id: Some("test-config-id".to_string()),
-            last_project_id: Some("123e4567-e89b-12d3-a456-426614174002".to_string()),
         };
 
         let json = serde_json::to_string(&config).unwrap();
@@ -579,7 +557,6 @@ mod tests {
         assert_eq!(config.api_url, deserialized.api_url);
         assert_eq!(config.api_key, deserialized.api_key);
         assert_eq!(config.config_id, deserialized.config_id);
-        assert_eq!(config.last_project_id, deserialized.last_project_id);
     }
 
     #[test]
@@ -595,7 +572,6 @@ mod tests {
         assert_eq!(config.api_url, "https://api.axiom.xyz/v1");
         assert_eq!(config.api_key, Some("test-key".to_string()));
         assert_eq!(config.config_id, Some("test-config".to_string()));
-        assert!(config.last_project_id.is_none());
     }
 
     #[test]

--- a/crates/sdk/src/projects.rs
+++ b/crates/sdk/src/projects.rs
@@ -176,7 +176,6 @@ mod tests {
             api_url: "https://api.test.com/v1".to_string(),
             api_key: None, // No API key
             config_id: None,
-            last_project_id: None,
         };
         let sdk = AxiomSdk::new(config);
 


### PR DESCRIPTION
- in the guest program, `cargo axiom build` first time will create a `.axiom/project-id` file and put the project id there
- later build within the same program will reuse the project id
- remove project id from config , as it's not a global property

fix: INT-4923

Tested without specifying project id: 

<img width="1449" height="301" alt="Screenshot 2025-08-28 at 2 31 40 PM" src="https://github.com/user-attachments/assets/52f22f61-b6e9-45eb-96ae-a101efae522b" />
