### PR TITLE
feat: cli changes to handle backend merging verify endpoints

### DIFF
--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -23,6 +23,10 @@ enum ProveSubcommand {
         /// The proof ID to check status for
         #[clap(long, value_name = "ID")]
         proof_id: String,
+
+        /// Wait for the proof to complete
+        #[clap(long)]
+        wait: bool,
     },
     /// Download logs for a proof
     Logs {
@@ -67,9 +71,9 @@ pub struct ProveArgs {
     #[clap(long = "type", default_value = "stark")]
     proof_type: ProofType,
 
-    /// Wait for the proof to complete and download artifacts
+    /// Run in detached mode (don't wait for completion)
     #[clap(long)]
-    wait: bool,
+    detach: bool,
 }
 
 impl ProveCmd {
@@ -79,10 +83,14 @@ impl ProveCmd {
         let sdk = AxiomSdk::new(config.clone()).with_callback(callback);
 
         match self.command {
-            Some(ProveSubcommand::Status { proof_id }) => {
-                let proof_status = sdk.get_proof_status(&proof_id)?;
-                Self::print_proof_status(&proof_status);
-                Ok(())
+            Some(ProveSubcommand::Status { proof_id, wait }) => {
+                if wait {
+                    sdk.wait_for_proof_completion(&proof_id)
+                } else {
+                    let proof_status = sdk.get_proof_status(&proof_id)?;
+                    Self::print_proof_status(&proof_status);
+                    Ok(())
+                }
             }
             Some(ProveSubcommand::Download {
                 proof_id,
@@ -129,7 +137,7 @@ impl ProveCmd {
                 };
                 let proof_id = sdk.generate_new_proof(args)?;
 
-                if self.prove_args.wait {
+                if !self.prove_args.detach {
                     sdk.wait_for_proof_completion(&proof_id)
                 } else {
                     println!(

--- a/crates/sdk/src/prove.rs
+++ b/crates/sdk/src/prove.rs
@@ -336,45 +336,29 @@ impl AxiomSdk {
                     callback.on_field("Program ID", &proof_status.program_uuid);
                     callback.on_field("Proof Type", &proof_status.proof_type);
 
+                    // Use same directory structure as download: program-{uuid}/proofs/{proof_id}/
                     let proof_dir = format!(
-                        "axiom-artifacts/program-{}/proofs",
-                        proof_status.program_uuid
+                        "axiom-artifacts/program-{}/proofs/{}",
+                        proof_status.program_uuid, proof_status.id
                     );
                     std::fs::create_dir_all(&proof_dir).ok();
 
-                    if proof_status.proof_type == "stark" {
-                        let proof_path = format!("{}/{}.stark", proof_dir, proof_status.id);
-                        if self
-                            .save_proof_to_path(
-                                &proof_status.id,
-                                &proof_status.proof_type.parse()?,
-                                std::path::PathBuf::from(&proof_path),
-                            )
-                            .is_ok()
-                        {
-                            callback.on_success(&format!("STARK proof saved to {}", proof_path));
-                        }
-                    } else {
-                        let proof_type_name = match proof_status.proof_type.as_str() {
-                            "evm" => "evm",
-                            _ => &proof_status.proof_type,
-                        };
-                        let proof_path =
-                            format!("{}/{}.{}", proof_dir, proof_status.id, proof_type_name);
-                        if self
-                            .save_proof_to_path(
-                                &proof_status.id,
-                                &proof_status.proof_type.parse()?,
-                                std::path::PathBuf::from(&proof_path),
-                            )
-                            .is_ok()
-                        {
-                            callback.on_success(&format!(
-                                "{} proof saved to {}",
-                                proof_type_name.to_uppercase(),
-                                proof_path
-                            ));
-                        }
+                    // Use same naming convention as download: {proof_type}-proof.json
+                    let proof_path =
+                        format!("{}/{}-proof.json", proof_dir, proof_status.proof_type);
+                    if self
+                        .save_proof_to_path(
+                            &proof_status.id,
+                            &proof_status.proof_type.parse()?,
+                            std::path::PathBuf::from(&proof_path),
+                        )
+                        .is_ok()
+                    {
+                        callback.on_success(&format!(
+                            "{} proof saved to {}",
+                            proof_status.proof_type.to_uppercase(),
+                            proof_path
+                        ));
                     }
 
                     let logs_path = format!("{}/logs.txt", proof_dir);


### PR DESCRIPTION
This PR makes the necessary changes on the CLI / SDK following the API's merge of the verify stark and verify evm endpoints. 

It also makes the output of `prove download` and `prove --wait` go to the same file and dir path.


<img width="1106" height="246" alt="image" src="https://github.com/user-attachments/assets/fdb9af16-6fec-40f4-b814-5dbd0173bbdc" />



Towards INT-4939