### PR TITLE
feat: execution modes

### DIFF
--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -254,9 +254,5 @@ impl BuildCmd {
         if let Some(error_message) = &status.error_message {
             Formatter::print_field("Error", error_message);
         }
-
-        Formatter::print_section("Statistics");
-        Formatter::print_field("Cells Used", &status.cells_used.to_string());
-        Formatter::print_field("Proofs Run", &status.proofs_run.to_string());
     }
 }

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -20,10 +20,6 @@ enum RunSubcommand {
         /// The execution ID to check status for
         #[clap(long, value_name = "ID")]
         execution_id: String,
-
-        /// Wait for the execution to complete
-        #[clap(long)]
-        wait: bool,
     },
 }
 
@@ -37,6 +33,10 @@ pub struct RunArgs {
     #[clap(long, value_parser, help = "Input to OpenVM program")]
     input: Option<Input>,
 
+    /// Execution mode: pure (output only), meter (output + cost + instructions), segment (output + segments + instructions)
+    #[clap(long, default_value = "pure", value_parser = ["pure", "meter", "segment"], help = "Execution mode")]
+    mode: String,
+
     /// Run in detached mode (don't wait for completion)
     #[clap(long)]
     detach: bool,
@@ -49,14 +49,10 @@ impl RunCmd {
         let sdk = AxiomSdk::new(config).with_callback(callback);
 
         match self.command {
-            Some(RunSubcommand::Status { execution_id, wait }) => {
-                if wait {
-                    sdk.wait_for_execution_completion(&execution_id)
-                } else {
-                    let execution_status = sdk.get_execution_status(&execution_id)?;
-                    Self::print_execution_status(&execution_status);
-                    Ok(())
-                }
+            Some(RunSubcommand::Status { execution_id }) => {
+                let execution_status = sdk.get_execution_status(&execution_id)?;
+                Self::print_execution_status(&execution_status);
+                Ok(())
             }
             None => {
                 use crate::progress::CliProgressCallback;
@@ -65,6 +61,7 @@ impl RunCmd {
                 let args = axiom_sdk::run::RunArgs {
                     program_id: self.run_args.program_id,
                     input: self.run_args.input,
+                    mode: self.run_args.mode,
                 };
                 let execution_id = sdk.execute_program(args)?;
 
@@ -86,6 +83,7 @@ impl RunCmd {
         Formatter::print_section("Execution Status");
         Formatter::print_field("ID", &status.id);
         Formatter::print_field("Status", &status.status);
+        Formatter::print_field("Mode", &status.mode);
         Formatter::print_field("Program ID", &status.program_uuid);
         Formatter::print_field("Created By", &status.created_by);
         Formatter::print_field("Created At", &status.created_at);
@@ -102,18 +100,41 @@ impl RunCmd {
             Formatter::print_field("Error", error_message);
         }
 
-        if let Some(total_cycle) = status.total_cycle {
-            Formatter::print_section("Execution Statistics");
-            Formatter::print_field("Total Cycles", &total_cycle.to_string());
-        }
-
-        if let Some(total_tick) = status.total_tick {
-            if status.total_cycle.is_none() {
-                Formatter::print_section("Execution Statistics");
+        // Show mode-specific statistics
+        match status.mode.as_str() {
+            "meter" => {
+                if status.cost.is_some() || status.total_cycle.is_some() {
+                    Formatter::print_section("Execution Statistics");
+                }
+                if let Some(cost) = status.cost {
+                    Formatter::print_field("Cost", &cost.to_string());
+                }
+                if let Some(total_cycle) = status.total_cycle {
+                    Formatter::print_field("Total Cycles", &total_cycle.to_string());
+                }
             }
-            Formatter::print_field("Total Ticks", &total_tick.to_string());
+            "segment" => {
+                if status.num_segments.is_some() || status.total_cycle.is_some() {
+                    Formatter::print_section("Execution Statistics");
+                }
+                if let Some(num_segments) = status.num_segments {
+                    Formatter::print_field("Number of Segments", &num_segments.to_string());
+                }
+                if let Some(total_cycle) = status.total_cycle {
+                    Formatter::print_field("Total Cycles", &total_cycle.to_string());
+                }
+            }
+            "pure" => {
+                // Pure mode only shows public values, no statistics
+            }
+            _ => {
+                // For other modes, show cycles if available
+                if let Some(total_cycle) = status.total_cycle {
+                    Formatter::print_section("Execution Statistics");
+                    Formatter::print_field("Total Cycles", &total_cycle.to_string());
+                }
+            }
         }
-
         // Format public values more nicely
         if let Some(public_values) = &status.public_values {
             if !public_values.is_null() {

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -111,10 +111,15 @@ impl VerifyCmd {
     }
 
     fn print_verify_status(status: &axiom_sdk::verify::VerifyStatus) {
-        Formatter::print_section("Verification Status");
-        Formatter::print_field("ID", &status.id);
+        // Just show the status information, no completion messages
+        Formatter::print_section("Verification Summary");
+        match status.result.as_str() {
+            "verified" => Formatter::print_field("Verification Result", "✓ VERIFIED"),
+            "failed" => Formatter::print_field("Verification Result", "✗ FAILED"),
+            _ => Formatter::print_field("Verification Result", &status.result.to_uppercase()),
+        }
+        Formatter::print_field("Verification ID", &status.id);
         Formatter::print_field("Proof Type", &status.proof_type.to_uppercase());
-        Formatter::print_field("Result", &status.result);
         Formatter::print_field("Created At", &status.created_at);
     }
 }


### PR DESCRIPTION
# Execution Modes

This PR adds execution modes to `cargo axiom run` paralleling those of `cargo openvm`. `cargo axiom run` will support the following modes:
- pure (default)
- meter
- segment

This follows the backend support of the above execution modes.

# Output Inconsistencies 

Additionally, this PR coalesces discrepancies between the output of `status` subcommands and the output of commands that poll until completion. See an example of proving below.

## Polled to Completion 

### Before

<img width="1235" height="381" alt="image" src="https://github.com/user-attachments/assets/c0c6fb73-e63a-4f35-ac9c-b3ff678b9827" />

### After 

<img width="1339" height="550" alt="image" src="https://github.com/user-attachments/assets/ead0426e-1f46-4a39-a302-ab6bddab46e8" />

## `prove status`
<img width="979" height="299" alt="image" src="https://github.com/user-attachments/assets/82f89eb7-dbde-4079-8526-1e4c111f13d6" />

Closes INT-4788