### PR TITLE
feat: per-org gpu quota

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "axiom-sdk"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cargo-openvm",
  "cargo_metadata 0.21.0",
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-axiom"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "axiom-sdk",
  "cargo-openvm",

--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -259,5 +259,6 @@ impl BuildCmd {
         if let Some(error_message) = &status.error_message {
             Formatter::print_field("Error", error_message);
         }
+        Formatter::print_field("Default Num GPUs", &status.default_num_gpus.to_string());
     }
 }

--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -95,7 +95,7 @@ pub struct BuildArgs {
 
     /// Specify default_num_gpus for this program
     #[clap(long)]
-    default_num_gpus: Option<usize>
+    default_num_gpus: Option<usize>,
 }
 
 impl BuildCmd {
@@ -190,7 +190,7 @@ impl BuildCmd {
                     project_id,
                     project_name: project_name_for_creation.clone(),
                     allow_dirty: self.build_args.allow_dirty,
-                    default_num_gpus: self.build_args.default_num_gpus
+                    default_num_gpus: self.build_args.default_num_gpus,
                 };
                 let program_id = sdk.register_new_program(&program_dir, args)?;
 

--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -92,6 +92,10 @@ pub struct BuildArgs {
     /// Allow building with uncommitted changes
     #[clap(long)]
     allow_dirty: bool,
+
+    /// Specify default_num_gpus for this program
+    #[clap(long)]
+    default_num_gpus: Option<usize>
 }
 
 impl BuildCmd {
@@ -186,6 +190,7 @@ impl BuildCmd {
                     project_id,
                     project_name: project_name_for_creation.clone(),
                     allow_dirty: self.build_args.allow_dirty,
+                    default_num_gpus: self.build_args.default_num_gpus
                 };
                 let program_id = sdk.register_new_program(&program_dir, args)?;
 

--- a/crates/cli/src/commands/download_keys.rs
+++ b/crates/cli/src/commands/download_keys.rs
@@ -1,9 +1,10 @@
 use std::path::PathBuf;
 
-use crate::progress::CliProgressCallback;
 use axiom_sdk::{AxiomSdk, config::ConfigSdk};
 use clap::Args;
 use eyre::Result;
+
+use crate::progress::CliProgressCallback;
 
 #[derive(Args, Debug)]
 pub struct DownloadKeysCmd {

--- a/crates/cli/src/commands/projects.rs
+++ b/crates/cli/src/commands/projects.rs
@@ -1,8 +1,9 @@
-use crate::progress::CliProgressCallback;
 use axiom_sdk::{AxiomSdk, projects::ProjectSdk};
 use clap::{Args, Subcommand};
 use comfy_table::Table;
 use eyre::Result;
+
+use crate::progress::CliProgressCallback;
 
 #[derive(Args, Debug)]
 pub struct ProjectsCmd {

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -74,6 +74,10 @@ pub struct ProveArgs {
     /// Run in detached mode (don't wait for completion)
     #[clap(long)]
     detach: bool,
+
+    /// Num GPUs to use for this proof
+    #[clap(long)]
+    num_gpus: Option<usize>
 }
 
 impl ProveCmd {
@@ -134,6 +138,7 @@ impl ProveCmd {
                     program_id: self.prove_args.program_id,
                     input: self.prove_args.input,
                     proof_type: Some(self.prove_args.proof_type),
+                    num_gpus: self.prove_args.num_gpus
                 };
                 let proof_id = sdk.generate_new_proof(args)?;
 

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -10,7 +10,7 @@ use crate::{formatting::Formatter, progress::CliProgressCallback};
 
 fn validate_priority(s: &str) -> Result<u8, String> {
     let priority: u8 = s.parse().map_err(|_| "Priority must be a number")?;
-    if priority >= 1 && priority <= 10 {
+    if (1..=10).contains(&priority) {
         Ok(priority)
     } else {
         Err("Priority must be between 1 and 10".to_string())
@@ -19,7 +19,7 @@ fn validate_priority(s: &str) -> Result<u8, String> {
 
 fn validate_num_gpus(s: &str) -> Result<usize, String> {
     let num_gpus: usize = s.parse().map_err(|_| "Number of GPUs must be a number")?;
-    if num_gpus >= 1 && num_gpus <= 10000 {
+    if (1..=10000).contains(&num_gpus) {
         Ok(num_gpus)
     } else {
         Err("Number of GPUs must be between 1 and 10000".to_string())
@@ -198,6 +198,10 @@ impl ProveCmd {
         if let Some(error_message) = &status.error_message {
             Formatter::print_field("Error", error_message);
         }
+
+        Formatter::print_section("Configuration");
+        Formatter::print_field("Num GPUs", &status.num_gpus.to_string());
+        Formatter::print_field("Priority", &status.priority.to_string());
 
         Formatter::print_section("Statistics");
         Formatter::print_field("Cells Used", &status.cells_used.to_string());

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -1,8 +1,9 @@
-use crate::{formatting::Formatter, progress::CliProgressCallback};
 use axiom_sdk::{AxiomSdk, run::RunSdk};
 use cargo_openvm::input::Input;
 use clap::{Args, Subcommand};
 use eyre::Result;
+
+use crate::{formatting::Formatter, progress::CliProgressCallback};
 
 #[derive(Args, Debug)]
 pub struct RunCmd {

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -1,9 +1,10 @@
 use std::path::PathBuf;
 
-use crate::{formatting::Formatter, progress::CliProgressCallback};
 use axiom_sdk::{AxiomSdk, verify::VerifySdk};
 use clap::{Args, Subcommand};
 use eyre::Result;
+
+use crate::{formatting::Formatter, progress::CliProgressCallback};
 
 #[derive(Args, Debug)]
 pub struct VerifyCmd {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,11 +1,10 @@
-use std::process;
+use std::{fs, path::PathBuf, process};
 
 use axiom_sdk::set_cli_version;
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use clap_complete::{Shell, generate};
 use dotenvy::dotenv;
 use eyre::Result;
-use std::{fs, path::PathBuf};
 
 mod commands;
 mod formatting;

--- a/crates/cli/src/progress.rs
+++ b/crates/cli/src/progress.rs
@@ -1,7 +1,9 @@
-use crate::formatting::Formatter;
+use std::sync::Mutex;
+
 use axiom_sdk::ProgressCallback;
 use indicatif::ProgressBar;
-use std::sync::Mutex;
+
+use crate::formatting::Formatter;
 
 pub struct CliProgressCallback {
     progress_bar: Mutex<Option<ProgressBar>>,

--- a/crates/sdk/src/build.rs
+++ b/crates/sdk/src/build.rs
@@ -58,7 +58,7 @@ pub struct BuildStatus {
     pub proofs_run: u64,
     pub project_id: String,
     pub project_name: String,
-    pub default_num_gpus: usize
+    pub default_num_gpus: usize,
 }
 
 #[derive(Debug)]
@@ -80,7 +80,7 @@ pub struct BuildArgs {
     /// Allow building with uncommitted changes
     pub allow_dirty: bool,
     /// Set default num gpus for this program
-    pub default_num_gpus: Option<usize>
+    pub default_num_gpus: Option<usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -309,7 +309,7 @@ impl AxiomSdk {
                     callback.on_field("Created By", &build_status.created_by);
                     callback.on_field("Created At", &build_status.created_at);
                     callback.on_field("Last Active", &build_status.last_active_at);
-                    callback.on_field("Num GPUs", &build_status.default_num_gpus);
+                    callback.on_field("Num GPUs", &build_status.default_num_gpus.to_string());
 
                     if let Some(launched_at) = &build_status.launched_at {
                         callback.on_field("Launched At", launched_at);
@@ -572,6 +572,9 @@ impl AxiomSdk {
         if let Ok(sha) = get_git_commit_sha(&git_root) {
             url.push_str(&format!("&commit_sha={sha}"));
         }
+        if let Some(default_num_gpus) = args.default_num_gpus {
+            url.push_str(&format!("&default_num_gpus={}", default_num_gpus));
+        }
 
         callback.on_header("Building Program");
 
@@ -581,6 +584,10 @@ impl AxiomSdk {
             callback.on_field("Config File", &path);
         } else {
             callback.on_field("Config", "Default");
+        }
+
+        if let Some(default_num_gpus) = args.default_num_gpus {
+            callback.on_field("Default Num GPUs", &default_num_gpus.to_string());
         }
 
         // Start progress tracking for upload

--- a/crates/sdk/src/build.rs
+++ b/crates/sdk/src/build.rs
@@ -309,7 +309,10 @@ impl AxiomSdk {
                     callback.on_field("Created By", &build_status.created_by);
                     callback.on_field("Created At", &build_status.created_at);
                     callback.on_field("Last Active", &build_status.last_active_at);
-                    callback.on_field("Num GPUs", &build_status.default_num_gpus.to_string());
+                    callback.on_field(
+                        "Default Num GPUs",
+                        &build_status.default_num_gpus.to_string(),
+                    );
 
                     if let Some(launched_at) = &build_status.launched_at {
                         callback.on_field("Launched At", launched_at);

--- a/crates/sdk/src/build.rs
+++ b/crates/sdk/src/build.rs
@@ -58,6 +58,7 @@ pub struct BuildStatus {
     pub proofs_run: u64,
     pub project_id: String,
     pub project_name: String,
+    pub default_num_gpus: usize
 }
 
 #[derive(Debug)]
@@ -78,6 +79,8 @@ pub struct BuildArgs {
     pub project_name: Option<String>,
     /// Allow building with uncommitted changes
     pub allow_dirty: bool,
+    /// Set default num gpus for this program
+    pub default_num_gpus: Option<usize>
 }
 
 #[derive(Debug, Clone)]
@@ -306,6 +309,7 @@ impl AxiomSdk {
                     callback.on_field("Created By", &build_status.created_by);
                     callback.on_field("Created At", &build_status.created_at);
                     callback.on_field("Last Active", &build_status.last_active_at);
+                    callback.on_field("Num GPUs", &build_status.default_num_gpus);
 
                     if let Some(launched_at) = &build_status.launched_at {
                         callback.on_field("Launched At", launched_at);

--- a/crates/sdk/src/prove.rs
+++ b/crates/sdk/src/prove.rs
@@ -42,6 +42,8 @@ pub struct ProveArgs {
     pub input: Option<Input>,
     /// The type of proof to generate (stark or evm)
     pub proof_type: Option<ProofType>,
+    /// The num gpus to use for this proof
+    pub num_gpus: Option<usize>
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -57,6 +59,7 @@ pub struct ProofStatus {
     pub created_by: String,
     pub cells_used: u64,
     pub num_instructions: Option<u64>,
+    pub num_gpus: usize
 }
 
 impl ProveSdk for AxiomSdk {

--- a/crates/sdk/src/prove.rs
+++ b/crates/sdk/src/prove.rs
@@ -62,6 +62,7 @@ pub struct ProofStatus {
     pub cells_used: u64,
     pub num_instructions: Option<u64>,
     pub num_gpus: usize,
+    pub priority: u8,
 }
 
 impl ProveSdk for AxiomSdk {
@@ -376,6 +377,10 @@ impl AxiomSdk {
                     if let Some(error_message) = &proof_status.error_message {
                         callback.on_field("Error", error_message);
                     }
+
+                    callback.on_section("Configuration");
+                    callback.on_field("Num GPUs", &proof_status.num_gpus.to_string());
+                    callback.on_field("Priority", &proof_status.priority.to_string());
 
                     callback.on_section("Statistics");
                     callback.on_field("Cells Used", &proof_status.cells_used.to_string());


### PR DESCRIPTION
This PR adds the changes to
- support specifying optional default_num_gpus in registering program 
- support specifying optional num_gpus and priority in requesting proofs
- Currently there is no subcommand in program to update its configurations (e.g. project_id, default_num_gpus), and project_id re-assignment only happens in the project move subcommand. I think we should add an update subcommand to the program for the configuration update. I can do a separate PR if we're aligned on this.

closes INT-5080

This needs to be deployed with backend PR https://github.com/axiom-crypto/cloud-proving-backend/pull/581