### PR TITLE
refactor: centralize progress bar and streaming download/upload logic

### DIFF
--- a/crates/cli/src/progress.rs
+++ b/crates/cli/src/progress.rs
@@ -1,6 +1,6 @@
 use std::sync::Mutex;
 
-use axiom_sdk::ProgressCallback;
+use axiom_sdk::{ProgressCallback, TransferDirection};
 use indicatif::ProgressBar;
 
 use crate::formatting::Formatter;
@@ -50,16 +50,20 @@ impl ProgressCallback for CliProgressCallback {
         Formatter::print_status(text);
     }
 
-    fn on_progress_start(&self, message: &str, total: Option<u64>) {
+    fn on_progress_start(&self, message: &str, total: Option<u64>, direction: TransferDirection) {
         let pb = if let Some(total_bytes) = total {
-            if message.contains("Downloading") || message.contains("download") {
-                Formatter::create_download_progress(total_bytes)
-            } else {
-                Formatter::create_upload_progress(total_bytes)
+            match direction {
+                TransferDirection::Download => Formatter::create_download_progress(total_bytes),
+                TransferDirection::Upload => Formatter::create_upload_progress(total_bytes),
             }
         } else {
             Formatter::create_spinner(message)
         };
+        *self.progress_bar.lock().unwrap() = Some(pb);
+    }
+
+    fn on_spinner_start(&self, message: &str) {
+        let pb = Formatter::create_spinner(message);
         *self.progress_bar.lock().unwrap() = Some(pb);
     }
 

--- a/crates/sdk/src/build.rs
+++ b/crates/sdk/src/build.rs
@@ -1,7 +1,7 @@
 use std::{
     borrow::Cow,
     fs::File,
-    io::{Read, Write},
+    io::Read,
     path::Path,
     sync::{
         Arc,
@@ -19,8 +19,8 @@ use serde_json::Value;
 use tar::Builder;
 
 use crate::{
-    API_KEY_HEADER, AxiomSdk, ProgressCallback, add_cli_version_header, authenticated_get,
-    download_file, send_request_json,
+    API_KEY_HEADER, AxiomSdk, CountingReader, ProgressCallback, add_cli_version_header,
+    authenticated_get, send_request_json,
 };
 
 pub const MAX_PROGRAM_SIZE_MB: u64 = 2048;
@@ -153,22 +153,6 @@ impl Drop for TarFile {
     }
 }
 
-struct CountingReader<R: Read> {
-    inner: R,
-    progress: Arc<AtomicU64>,
-}
-
-impl<R: Read> Read for CountingReader<R> {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        let bytes_read = self.inner.read(buf)?;
-        if bytes_read > 0 {
-            self.progress
-                .fetch_add(bytes_read as u64, Ordering::Relaxed);
-        }
-        Ok(bytes_read)
-    }
-}
-
 impl BuildSdk for AxiomSdk {
     fn list_programs(
         &self,
@@ -266,30 +250,18 @@ impl BuildSdk for AxiomSdk {
             let content_length = response.content_length();
             let mut response = response;
 
-            if let Some(total) = content_length {
-                self.callback
-                    .on_progress_start(&format!("Downloading {}", program_type), Some(total));
-            } else {
-                self.callback
-                    .on_progress_start(&format!("Downloading {}", program_type), None);
-            }
+            self.callback.on_progress_start(
+                &format!("Downloading {program_type}"),
+                content_length,
+                crate::TransferDirection::Download,
+            );
 
-            if content_length.is_some() {
-                let mut buffer = vec![0u8; 1024 * 1024];
-                let mut downloaded = 0u64;
-
-                loop {
-                    let bytes_read = response.read(&mut buffer)?;
-                    if bytes_read == 0 {
-                        break;
-                    }
-                    file.write_all(&buffer[..bytes_read])?;
-                    downloaded += bytes_read as u64;
-                    self.callback.on_progress_update(downloaded);
-                }
-            } else {
-                std::io::copy(&mut response, &mut file)?;
-            }
+            crate::stream_response_to_file(
+                &mut response,
+                &mut file,
+                &*self.callback,
+                content_length.is_some(),
+            )?;
 
             self.callback.on_progress_finish("✓ Download complete");
             self.callback.on_success(&format!("{}", filename.display()));
@@ -329,9 +301,9 @@ impl BuildSdk for AxiomSdk {
 
         let filename = build_dir.join("logs.txt");
         let response = authenticated_get(&self.config, &url)?;
-        download_file(
+        crate::download_file_streaming(
             response,
-            Some(filename.clone()),
+            filename.clone(),
             "Failed to download build logs",
         )?;
         self.callback
@@ -373,7 +345,7 @@ impl AxiomSdk {
     ) -> Result<()> {
         use std::time::Duration;
 
-        callback.on_progress_start("Checking build status...", None);
+        callback.on_spinner_start("Checking build status...");
 
         loop {
             let response = authenticated_get(
@@ -679,7 +651,11 @@ impl AxiomSdk {
         }
 
         // Start progress tracking for upload
-        callback.on_progress_start("Uploading", Some(metadata.len()));
+        callback.on_progress_start(
+            "Uploading",
+            Some(metadata.len()),
+            crate::TransferDirection::Upload,
+        );
 
         // Use a counting reader and perform the request in a background thread while
         // polling progress from the main thread to update the callback.
@@ -957,7 +933,9 @@ impl AxiomSdk {
             .part("elf", elf_part)
             .part("vmexe", vmexe_part);
 
-        callback.on_progress_start("Uploading", None);
+        // No CountingReader here — bytes are sent in one shot, so a spinner is
+        // more honest than a progress bar that would jump from 0% to 100%.
+        callback.on_spinner_start("Uploading");
 
         let client = Client::builder()
             .timeout(std::time::Duration::from_secs(300))

--- a/crates/sdk/src/config.rs
+++ b/crates/sdk/src/config.rs
@@ -1,8 +1,4 @@
-use std::{
-    fs::File,
-    io::{Read, Write, copy},
-    path::PathBuf,
-};
+use std::{fs::File, io::copy, path::PathBuf};
 
 use bytes::Bytes;
 use eyre::{Context, OptionExt, Result};
@@ -61,29 +57,19 @@ impl PkDownloader {
         if response.status().is_success() {
             let content_length = response.content_length();
 
-            if let Some(total) = content_length {
-                callback.on_progress_start("Downloading proving key", Some(total));
-            } else {
-                callback.on_progress_start("Downloading proving key", None);
-            }
+            callback.on_progress_start(
+                "Downloading proving key",
+                content_length,
+                crate::TransferDirection::Download,
+            );
 
             let mut file = File::create(output_path)?;
-            if content_length.is_some() {
-                let mut buffer = vec![0u8; 1024 * 1024]; // 1MB buffer
-                let mut downloaded = 0u64;
-
-                loop {
-                    let bytes_read = response.read(&mut buffer)?;
-                    if bytes_read == 0 {
-                        break;
-                    }
-                    file.write_all(&buffer[..bytes_read])?;
-                    downloaded += bytes_read as u64;
-                    callback.on_progress_update(downloaded);
-                }
-            } else {
-                copy(&mut response, &mut file)?;
-            }
+            crate::stream_response_to_file(
+                &mut response,
+                &mut file,
+                callback,
+                content_length.is_some(),
+            )?;
             callback.on_progress_finish("✓ Key downloaded successfully");
             Ok(())
         } else if response.status().is_client_error() {

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -1,4 +1,10 @@
-use std::{path::PathBuf, sync::OnceLock};
+use std::{
+    path::PathBuf,
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicU64, Ordering},
+    },
+};
 
 use bytes::Bytes;
 use dirs::home_dir;
@@ -18,6 +24,16 @@ pub mod verify;
 
 pub const API_KEY_HEADER: &str = "Axiom-API-Key";
 pub const CLI_VERSION_HEADER: &str = "Axiom-CLI-Version";
+
+/// Buffer size for streaming chunked transfers (1 MiB).
+pub const CHUNK_SIZE: usize = 1024 * 1024;
+
+/// Indicates whether a transfer operation is a download or upload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransferDirection {
+    Download,
+    Upload,
+}
 static CLI_VERSION: OnceLock<String> = OnceLock::new();
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -80,7 +96,8 @@ pub const STAGING_DEFAULT_CONFIG_ID: &str = "cfg_01k43tmxayxwktkbh5wqsv10em";
 ///     fn on_section(&self, _title: &str) {}
 ///     fn on_field(&self, _key: &str, _value: &str) {}
 ///     fn on_status(&self, _text: &str) {}
-///     fn on_progress_start(&self, _message: &str, _total: Option<u64>) {}
+///     fn on_progress_start(&self, _message: &str, _total: Option<u64>, _direction: TransferDirection) {}
+///     fn on_spinner_start(&self, _message: &str) {}
 ///     fn on_progress_update(&self, _current: u64) {}
 ///     fn on_progress_update_message(&self, _message: &str) {}
 ///     fn on_progress_finish(&self, _message: &str) {}
@@ -112,7 +129,10 @@ pub trait ProgressCallback {
     /// # Parameters
     /// * `message` - Description of the operation being performed
     /// * `total` - Total number of units if known (for progress bars), None for spinners
-    fn on_progress_start(&self, message: &str, total: Option<u64>);
+    /// * `direction` - The type of transfer, used by UI to style the progress bar
+    fn on_progress_start(&self, message: &str, total: Option<u64>, direction: TransferDirection);
+    /// Called when starting a spinner for polling/waiting operations.
+    fn on_spinner_start(&self, message: &str);
     /// Called to update progress with the current completion count
     fn on_progress_update(&self, current: u64);
     /// Called to update the progress message without restarting
@@ -153,7 +173,14 @@ impl ProgressCallback for NoopCallback {
     fn on_section(&self, _title: &str) {}
     fn on_field(&self, _key: &str, _value: &str) {}
     fn on_status(&self, _text: &str) {}
-    fn on_progress_start(&self, _message: &str, _total: Option<u64>) {}
+    fn on_progress_start(
+        &self,
+        _message: &str,
+        _total: Option<u64>,
+        _direction: TransferDirection,
+    ) {
+    }
+    fn on_spinner_start(&self, _message: &str) {}
     fn on_progress_update(&self, _current: u64) {}
     fn on_progress_update_message(&self, _message: &str) {}
     fn on_progress_finish(&self, _message: &str) {}
@@ -457,6 +484,84 @@ fn handle_response(response: Response) -> Result<()> {
     } else {
         Err(eyre::eyre!(
             "Request failed with status: {}",
+            response.status()
+        ))
+    }
+}
+
+/// A reader wrapper that tracks total bytes read via an atomic counter.
+/// Useful for monitoring upload progress from a separate thread.
+pub struct CountingReader<R: std::io::Read> {
+    pub inner: R,
+    pub progress: Arc<AtomicU64>,
+}
+
+impl<R: std::io::Read> std::io::Read for CountingReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let bytes_read = self.inner.read(buf)?;
+        if bytes_read > 0 {
+            self.progress
+                .fetch_add(bytes_read as u64, Ordering::Relaxed);
+        }
+        Ok(bytes_read)
+    }
+}
+
+/// Stream a response body to a file, reporting progress via the callback.
+///
+/// When `has_content_length` is true, reports per-chunk progress updates;
+/// otherwise streams without progress updates. Always uses `CHUNK_SIZE` buffer.
+pub fn stream_response_to_file(
+    response: &mut reqwest::blocking::Response,
+    file: &mut std::fs::File,
+    callback: &dyn ProgressCallback,
+    has_content_length: bool,
+) -> Result<u64> {
+    let mut buffer = vec![0u8; CHUNK_SIZE];
+    let mut downloaded = 0u64;
+    loop {
+        let bytes_read = std::io::Read::read(response, &mut buffer)?;
+        if bytes_read == 0 {
+            break;
+        }
+        std::io::Write::write_all(file, &buffer[..bytes_read])?;
+        downloaded += bytes_read as u64;
+        if has_content_length {
+            callback.on_progress_update(downloaded);
+        }
+    }
+    Ok(downloaded)
+}
+
+/// Stream a download directly to a file without buffering in memory.
+pub fn download_file_streaming(
+    request_builder: RequestBuilder,
+    output_path: PathBuf,
+    error_context: &str,
+) -> Result<()> {
+    let mut response = request_builder
+        .send()
+        .with_context(|| error_context.to_string())?;
+
+    if response.status().is_success() {
+        if let Some(parent) = output_path.parent() {
+            std::fs::create_dir_all(parent)
+                .context(format!("Failed to create directory: {}", parent.display()))?;
+        }
+        let file = std::fs::File::create(&output_path).context(format!(
+            "Failed to create output file: {}",
+            output_path.display()
+        ))?;
+        let mut writer = std::io::BufWriter::with_capacity(CHUNK_SIZE, file);
+        std::io::copy(&mut response, &mut writer).context("Failed to write response to file")?;
+        Ok(())
+    } else if response.status().is_client_error() {
+        let status = response.status();
+        let error_text = response.text()?;
+        Err(eyre::eyre!("Client error ({}): {}", status, error_text))
+    } else {
+        Err(eyre::eyre!(
+            "Download request failed with status: {}",
             response.status()
         ))
     }

--- a/crates/sdk/src/prove.rs
+++ b/crates/sdk/src/prove.rs
@@ -1,14 +1,13 @@
-use std::{fs, io::copy, path::PathBuf};
+use std::{fs, path::PathBuf};
 
 use bytes::Bytes;
 use eyre::{Context, OptionExt, Result};
-use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use crate::{
-    API_KEY_HEADER, AxiomSdk, ProgressCallback, ProofType, add_cli_version_header,
-    authenticated_get, authenticated_post, download_file, input::Input, send_request_json,
+    AxiomSdk, ProgressCallback, ProofType, authenticated_get, authenticated_post, download_file,
+    input::Input, send_request_json,
 };
 
 const PROOF_POLLING_INTERVAL_SECS: u64 = 10;
@@ -124,9 +123,9 @@ impl ProveSdk for AxiomSdk {
         // Create file path in the proof directory
         let output_path = PathBuf::from(format!("{}/logs.txt", proof_dir));
         let request = authenticated_get(&self.config, &url)?;
-        download_file(
+        crate::download_file_streaming(
             request,
-            output_path.clone().into(),
+            output_path.clone(),
             "Failed to download proof logs",
         )?;
         self.callback
@@ -156,41 +155,8 @@ impl ProveSdk for AxiomSdk {
 
     fn save_proof_logs_to_path(&self, proof_id: &str, output_path: PathBuf) -> Result<()> {
         let url = format!("{}/proofs/{}/logs", self.config.api_url, proof_id);
-
-        let client = Client::new();
-        let api_key = self
-            .config
-            .api_key
-            .as_ref()
-            .ok_or(eyre::eyre!("API key not set"))?;
-
-        let response = add_cli_version_header(client.get(url).header(API_KEY_HEADER, api_key))
-            .send()
-            .context("Failed to send logs request")?;
-
-        if response.status().is_success() {
-            let mut file = fs::File::create(&output_path)
-                .context(format!("Failed to create output file: {output_path:?}"))?;
-
-            copy(
-                &mut response
-                    .bytes()
-                    .context("Failed to read response body")?
-                    .as_ref(),
-                &mut file,
-            )
-            .context("Failed to write response to file")?;
-
-            Ok(())
-        } else {
-            let status = response.status();
-            let error_text = response.text()?;
-            Err(eyre::eyre!(
-                "Logs download failed ({}): {}",
-                status,
-                error_text
-            ))
-        }
+        let request = authenticated_get(&self.config, &url)?;
+        crate::download_file_streaming(request, output_path, "Failed to download proof logs")
     }
 
     fn generate_new_proof(&self, args: ProveArgs) -> Result<String> {
@@ -423,7 +389,7 @@ impl AxiomSdk {
                 }
                 "Canceling" => {
                     if !spinner_started {
-                        callback.on_progress_start("Canceling proof", None);
+                        callback.on_spinner_start("Canceling proof");
                         spinner_started = true;
                     } else {
                         callback.on_progress_update_message("Canceling proof");
@@ -432,14 +398,14 @@ impl AxiomSdk {
                 }
                 "Queued" => {
                     if !spinner_started {
-                        callback.on_progress_start("Proof queued", None);
+                        callback.on_spinner_start("Proof queued");
                         spinner_started = true;
                     }
                     std::thread::sleep(Duration::from_secs(PROOF_POLLING_INTERVAL_SECS));
                 }
                 "InProgress" => {
                     if !spinner_started {
-                        callback.on_progress_start("Generating proof", None);
+                        callback.on_spinner_start("Generating proof");
                         spinner_started = true;
                     } else {
                         // Update message if we were previously in queued state
@@ -450,7 +416,7 @@ impl AxiomSdk {
                 _ => {
                     let status_message = format!("Proof status: {}", proof_status.state);
                     if !spinner_started {
-                        callback.on_progress_start(&status_message, None);
+                        callback.on_spinner_start(&status_message);
                         spinner_started = true;
                     } else {
                         callback.on_progress_update_message(&status_message);
@@ -489,7 +455,7 @@ impl AxiomSdk {
                 }
                 "Canceling" => {
                     if !spinner_started {
-                        callback.on_progress_start("Canceling proof", None);
+                        callback.on_spinner_start("Canceling proof");
                         spinner_started = true;
                     }
                     std::thread::sleep(Duration::from_secs(PROOF_POLLING_INTERVAL_SECS));
@@ -517,7 +483,7 @@ impl AxiomSdk {
                 _ => {
                     // For any other state (Queued, InProgress, etc.), keep waiting for cancellation
                     if !spinner_started {
-                        callback.on_progress_start("Waiting for cancellation", None);
+                        callback.on_spinner_start("Waiting for cancellation");
                         spinner_started = true;
                     }
                     std::thread::sleep(Duration::from_secs(PROOF_POLLING_INTERVAL_SECS));

--- a/crates/sdk/src/run.rs
+++ b/crates/sdk/src/run.rs
@@ -180,8 +180,6 @@ impl RunSdk for AxiomSdk {
     }
 
     fn get_execution_logs(&self, execution_id: &str) -> Result<()> {
-        use crate::download_file;
-
         let url = format!("{}/executions/{}/logs", self.config.api_url, execution_id);
         let request = crate::authenticated_get(&self.config, &url)?;
 
@@ -193,9 +191,9 @@ impl RunSdk for AxiomSdk {
         ))?;
 
         let filename = execution_dir.join("logs.txt");
-        download_file(
+        crate::download_file_streaming(
             request,
-            Some(filename.clone()),
+            filename.clone(),
             "Failed to download execution logs",
         )?;
         self.callback
@@ -397,14 +395,14 @@ impl AxiomSdk {
                 }
                 "Queued" => {
                     if !spinner_started {
-                        callback.on_progress_start("Execution queued", None);
+                        callback.on_spinner_start("Execution queued");
                         spinner_started = true;
                     }
                     std::thread::sleep(Duration::from_secs(EXECUTION_POLLING_INTERVAL_SECS));
                 }
                 "InProgress" => {
                     if !spinner_started {
-                        callback.on_progress_start("Executing program", None);
+                        callback.on_spinner_start("Executing program");
                         spinner_started = true;
                     } else {
                         // Update message if we were previously in queued state
@@ -415,7 +413,7 @@ impl AxiomSdk {
                 _ => {
                     let status_message = format!("Execution status: {}", execution_status.status);
                     if !spinner_started {
-                        callback.on_progress_start(&status_message, None);
+                        callback.on_spinner_start(&status_message);
                         spinner_started = true;
                     } else {
                         callback.on_progress_update_message(&status_message);

--- a/crates/sdk/src/verify.rs
+++ b/crates/sdk/src/verify.rs
@@ -318,7 +318,7 @@ impl AxiomSdk {
                 }
                 "processing" => {
                     if !spinner_started {
-                        callback.on_progress_start("Verifying proof", None);
+                        callback.on_spinner_start("Verifying proof");
                         spinner_started = true;
                     }
                     std::thread::sleep(Duration::from_secs(VERIFICATION_POLLING_INTERVAL_SECS));
@@ -326,7 +326,7 @@ impl AxiomSdk {
                 _ => {
                     let status_message = format!("Verification status: {}", verify_status.result);
                     if !spinner_started {
-                        callback.on_progress_start(&status_message, None);
+                        callback.on_spinner_start(&status_message);
                         spinner_started = true;
                     } else {
                         callback.on_progress_update_message(&status_message);
@@ -397,7 +397,7 @@ impl AxiomSdk {
                 }
                 "processing" => {
                     if !spinner_started {
-                        callback.on_progress_start("Verifying proof", None);
+                        callback.on_spinner_start("Verifying proof");
                         spinner_started = true;
                     }
                     std::thread::sleep(Duration::from_secs(VERIFICATION_POLLING_INTERVAL_SECS));
@@ -405,7 +405,7 @@ impl AxiomSdk {
                 _ => {
                     let status_message = format!("Verification status: {}", verify_status.result);
                     if !spinner_started {
-                        callback.on_progress_start(&status_message, None);
+                        callback.on_spinner_start(&status_message);
                         spinner_started = true;
                     } else {
                         callback.on_progress_update_message(&status_message);


### PR DESCRIPTION
## Summary
- Extract shared `stream_response_to_file()`, `download_file_streaming()`, and `CountingReader` into `lib.rs`
- Replace duplicated 1MB chunk loops in `config.rs` and `build.rs` with shared utility
- Add `TransferDirection` enum to replace brittle string-matching in progress bar dispatch
- Add `on_spinner_start()` trait method to cleanly separate spinners from progress bars
- Switch log downloads (build/prove/run) to streaming instead of buffering entire response in memory
- Simplify `save_proof_logs_to_path` from 35 lines to 3 using `download_file_streaming`
- Use `CHUNK_SIZE` constant (1 MiB) everywhere instead of hardcoded `1024 * 1024`

## Testing
- [ ] Manual test: `cargo axiom build` (upload with progress bar)
- [x] Manual test: `cargo axiom build download` (download with progress bar)
- [x] Manual test: `cargo axiom config download-pk` (proving key download)
- [ ] Manual test: `cargo axiom prove --wait` (spinner + log download)

Did not test prove/build as I do not have project at hand but should work as it's pretty trivial refactor.

---
Closes INT-4958