### PR TITLE
[codex] feat: add --vcs none

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,6 @@
    Alternatively, set the `AXIOM_API_KEY` environment variable in a `.env` file and then run `cargo axiom register` at the directory of the `.env` file.
    See `.env.example` for an example.
 
-To scaffold a new OpenVM project without creating a git repository, use:
-
-```bash
-cargo axiom init --vcs none <PATH>
-```
-
 ## Building Programs
 
 1. Navigate to your program directory (containing a Rust workspace with an OpenVM guest program).

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@
    Alternatively, set the `AXIOM_API_KEY` environment variable in a `.env` file and then run `cargo axiom register` at the directory of the `.env` file.
    See `.env.example` for an example.
 
+To scaffold a new OpenVM project without creating a git repository, use:
+
+```bash
+cargo axiom init --vcs none <PATH>
+```
+
 ## Building Programs
 
 1. Navigate to your program directory (containing a Rust workspace with an OpenVM guest program).

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -266,7 +266,7 @@ mod tests {
     }
 
     #[test]
-    fn build_openvm_init_command_omits_vcs_by_default() {
+    fn build_openvm_init_command_forwards_vcs_git() {
         let args = InitArgs {
             path: Some("guest".into()),
             name: Some("demo".into()),

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -39,8 +39,9 @@ impl InitCmd {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
 enum Vcs {
+    #[default]
     Git,
     None,
 }
@@ -65,8 +66,8 @@ pub struct InitArgs {
     name: Option<String>,
 
     /// Initialize a version control repository (`git` or `none`)
-    #[clap(long, value_enum, value_name = "VCS")]
-    vcs: Option<Vcs>,
+    #[clap(long, value_enum, value_name = "VCS", default_value_t = Vcs::Git)]
+    vcs: Vcs,
 }
 
 fn build_openvm_init_command(args: &InitArgs) -> Command {
@@ -81,15 +82,13 @@ fn build_openvm_init_command(args: &InitArgs) -> Command {
         cmd.arg("--name").arg(name);
     }
 
-    if let Some(vcs) = args.vcs {
-        cmd.arg("--vcs").arg(vcs.as_arg());
-    }
+    cmd.arg("--vcs").arg(args.vcs.as_arg());
 
     cmd
 }
 
-fn should_attempt_git_commit(vcs: Option<Vcs>) -> bool {
-    vcs.unwrap_or(Vcs::Git) == Vcs::Git
+fn should_attempt_git_commit(vcs: Vcs) -> bool {
+    vcs == Vcs::Git
 }
 
 pub fn execute(args: InitArgs) -> Result<()> {
@@ -275,12 +274,12 @@ mod tests {
         let args = InitArgs {
             path: Some("guest".into()),
             name: Some("demo".into()),
-            vcs: None,
+            vcs: Vcs::Git,
         };
 
         assert_eq!(
             command_args(&args),
-            vec!["openvm", "init", "guest", "--name", "demo"]
+            vec!["openvm", "init", "guest", "--name", "demo", "--vcs", "git"]
         );
     }
 
@@ -289,7 +288,7 @@ mod tests {
         let args = InitArgs {
             path: Some("guest".into()),
             name: None,
-            vcs: Some(Vcs::None),
+            vcs: Vcs::None,
         };
 
         assert_eq!(
@@ -300,8 +299,7 @@ mod tests {
 
     #[test]
     fn should_only_attempt_git_commit_for_git() {
-        assert!(should_attempt_git_commit(None));
-        assert!(should_attempt_git_commit(Some(Vcs::Git)));
-        assert!(!should_attempt_git_commit(Some(Vcs::None)));
+        assert!(should_attempt_git_commit(Vcs::Git));
+        assert!(!should_attempt_git_commit(Vcs::None));
     }
 }

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -87,10 +87,6 @@ fn build_openvm_init_command(args: &InitArgs) -> Command {
     cmd
 }
 
-fn should_attempt_git_commit(vcs: Vcs) -> bool {
-    vcs == Vcs::Git
-}
-
 pub fn execute(args: InitArgs) -> Result<()> {
     println!("Initializing OpenVM project...");
 
@@ -244,7 +240,7 @@ pub fn execute(args: InitArgs) -> Result<()> {
         .status();
 
     // Attempt to stage and commit initialized files. Ignore failures (e.g., not a git repo or nothing to commit).
-    if should_attempt_git_commit(args.vcs) {
+    if args.vcs == Vcs::Git {
         let _ = Command::new("git")
             .current_dir(&project_dir)
             .args(["add", "."])
@@ -260,7 +256,7 @@ pub fn execute(args: InitArgs) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{InitArgs, Vcs, build_openvm_init_command, should_attempt_git_commit};
+    use super::{InitArgs, Vcs, build_openvm_init_command};
 
     fn command_args(args: &InitArgs) -> Vec<String> {
         build_openvm_init_command(args)
@@ -295,11 +291,5 @@ mod tests {
             command_args(&args),
             vec!["openvm", "init", "guest", "--vcs", "none"]
         );
-    }
-
-    #[test]
-    fn should_only_attempt_git_commit_for_git() {
-        assert!(should_attempt_git_commit(Vcs::Git));
-        assert!(!should_attempt_git_commit(Vcs::None));
     }
 }

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::Path, process::Command};
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use eyre::{OptionExt, Result, WrapErr, bail};
 use toml_edit::{DocumentMut, Item, Table, Value};
 
@@ -39,6 +39,21 @@ impl InitCmd {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum Vcs {
+    Git,
+    None,
+}
+
+impl Vcs {
+    fn as_arg(self) -> &'static str {
+        match self {
+            Self::Git => "git",
+            Self::None => "none",
+        }
+    }
+}
+
 #[derive(Debug, Parser)]
 pub struct InitArgs {
     /// Path to create the package in
@@ -48,6 +63,33 @@ pub struct InitArgs {
     /// Set the package name, default is the directory name
     #[clap(long, value_name = "NAME")]
     name: Option<String>,
+
+    /// Initialize a version control repository (`git` or `none`)
+    #[clap(long, value_enum, value_name = "VCS")]
+    vcs: Option<Vcs>,
+}
+
+fn build_openvm_init_command(args: &InitArgs) -> Command {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("openvm").arg("init");
+
+    if let Some(path) = &args.path {
+        cmd.arg(path);
+    }
+
+    if let Some(name) = &args.name {
+        cmd.arg("--name").arg(name);
+    }
+
+    if let Some(vcs) = args.vcs {
+        cmd.arg("--vcs").arg(vcs.as_arg());
+    }
+
+    cmd
+}
+
+fn should_attempt_git_commit(vcs: Option<Vcs>) -> bool {
+    vcs.unwrap_or(Vcs::Git) == Vcs::Git
 }
 
 pub fn execute(args: InitArgs) -> Result<()> {
@@ -65,18 +107,7 @@ pub fn execute(args: InitArgs) -> Result<()> {
     }
 
     // Build the cargo openvm init command
-    let mut cmd = Command::new("cargo");
-    cmd.arg("openvm").arg("init");
-
-    // Add path if provided
-    if let Some(path) = &args.path {
-        cmd.arg(path);
-    }
-
-    // Add name if provided
-    if let Some(name) = &args.name {
-        cmd.arg("--name").arg(name);
-    }
+    let mut cmd = build_openvm_init_command(&args);
 
     // Execute cargo openvm init
     let status = cmd.status()?;
@@ -214,14 +245,63 @@ pub fn execute(args: InitArgs) -> Result<()> {
         .status();
 
     // Attempt to stage and commit initialized files. Ignore failures (e.g., not a git repo or nothing to commit).
-    let _ = Command::new("git")
-        .current_dir(&project_dir)
-        .args(["add", "."])
-        .status();
-    let _ = Command::new("git")
-        .current_dir(&project_dir)
-        .args(["commit", "-q", "-m", "initial commit"])
-        .status();
+    if should_attempt_git_commit(args.vcs) {
+        let _ = Command::new("git")
+            .current_dir(&project_dir)
+            .args(["add", "."])
+            .status();
+        let _ = Command::new("git")
+            .current_dir(&project_dir)
+            .args(["commit", "-q", "-m", "initial commit"])
+            .status();
+    }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{InitArgs, Vcs, build_openvm_init_command, should_attempt_git_commit};
+
+    fn command_args(args: &InitArgs) -> Vec<String> {
+        build_openvm_init_command(args)
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn build_openvm_init_command_omits_vcs_by_default() {
+        let args = InitArgs {
+            path: Some("guest".into()),
+            name: Some("demo".into()),
+            vcs: None,
+        };
+
+        assert_eq!(
+            command_args(&args),
+            vec!["openvm", "init", "guest", "--name", "demo"]
+        );
+    }
+
+    #[test]
+    fn build_openvm_init_command_forwards_vcs_none() {
+        let args = InitArgs {
+            path: Some("guest".into()),
+            name: None,
+            vcs: Some(Vcs::None),
+        };
+
+        assert_eq!(
+            command_args(&args),
+            vec!["openvm", "init", "guest", "--vcs", "none"]
+        );
+    }
+
+    #[test]
+    fn should_only_attempt_git_commit_for_git() {
+        assert!(should_attempt_git_commit(None));
+        assert!(should_attempt_git_commit(Some(Vcs::Git)));
+        assert!(!should_attempt_git_commit(Some(Vcs::None)));
+    }
 }


### PR DESCRIPTION
Current wrapper always follows OpenVM's default git initialization path, which is inconvenient for CI, automation, tests, and creating guest program directories inside an existing repository.

This PR adds a `--vcs <git|none>` option to `cargo axiom init` and forward it to `cargo openvm init`.

---
Closes INT-5197