### PR TITLE
chore: bump toolchain 1.90.0 -> 1.93.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.93.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
1.90 is below openvm v2's MSRV (1.91.1), which traps any 'cargo install' of openvm tooling run from inside this repo's directory (rustup resolves the toolchain pin from cwd). The CLI has no MSRV of its own and no openvm deps; workspace builds clean on 1.93.0 and the two axiom-sdk doctest failures reproduce identically on 1.90 (pre-existing, env-dependent).